### PR TITLE
Improving output capture in step definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testjam-io",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "testjam.io: An online coding environment specifically designed for Cucumber and Gherkin.",
   "main": "index.js",
   "scripts": {
@@ -58,8 +58,8 @@
     "styled-components": "^5.3.5"
   },
   "build": {
-    "version": "0.8.6",
-    "date": "2022-07-07T17:11:00Z"
+    "version": "0.8.7",
+    "date": "2022-07-09T16:02:00Z"
   },
   "devDependencies": {
     "browserify": "^17.0.0",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -6,8 +6,8 @@ export default class Logger {
     }
 
     log(data) {
-        this.events.emit('logInfo', data);
-        this.events.emit('output', data);
+        this.events.emit('logInfo', `${data}\n`);
+        this.events.emit('output', `${data}\n`);
     }
 
     warn(data) {

--- a/src/runtimes/javascript/cucumberjs1x.js
+++ b/src/runtimes/javascript/cucumberjs1x.js
@@ -27,10 +27,10 @@ function execute({
     const functions = stepDefinitions
         .map(stepDefinitionFormatter)
         // eslint-disable-next-line no-new-func
-        .map((i) => new Function('__dependencies', i));
+        .map((i) => new Function('__dependencies', 'console', i));
 
     function supportCode() {
-        functions.forEach((f) => f.call(this, dependencies)); // eslint-disable-line no-new-func
+        functions.forEach((f) => f.call(this, dependencies, logger));
     }
 
     const instance = cucumber(loadedFeatures, supportCode);
@@ -38,7 +38,7 @@ function execute({
     const formatterOptions = {
         colorsEnabled: true,
         language: dialect,
-        logToFunction: (i) => logger.log(i),
+        logToFunction: (i) => logger.info(i),
     };
 
     const listener = cucumber.Listener.PrettyFormatter(formatterOptions);

--- a/src/runtimes/javascript/cucumberjs2x.js
+++ b/src/runtimes/javascript/cucumberjs2x.js
@@ -32,7 +32,8 @@ function execute({
     cucumber.clearSupportCodeFns();
     stepDefinitions
         .map(stepDefinitionFormatter)
-        .forEach((i) => new Function('__dependencies', i)(dependencies)); // eslint-disable-line no-new-func
+        // eslint-disable-next-line no-new-func
+        .forEach((i) => new Function('__dependencies', 'console', i)(dependencies, logger));
 
     const supportCodeLibrary = cucumber.SupportCodeLibraryBuilder.build({
         cwd: '/',
@@ -42,7 +43,7 @@ function execute({
     const formatterOptions = {
         colorsEnabled: true,
         cwd: '/',
-        log: (i) => logger.log(i),
+        log: (i) => logger.info(i),
         supportCodeLibrary,
     };
     const prettyFormatter = cucumber.FormatterBuilder.build('pretty', formatterOptions);

--- a/src/runtimes/javascript/cucumberjsLegacyRuntime.js
+++ b/src/runtimes/javascript/cucumberjsLegacyRuntime.js
@@ -107,7 +107,8 @@ function cucumberRuntimeBuilder(version) {
                                 cucumber.supportCodeLibraryBuilder.reset('');
                                 stepDefinitions
                                     .map(stepDefinitionFormatter)
-                                    .forEach((i) => new Function('__dependencies', i)(dependencies)); // eslint-disable-line no-new-func
+                                    // eslint-disable-next-line no-new-func
+                                    .forEach((i) => new Function('__dependencies', 'console', i)(dependencies, logger));
                                 _context.next = 10;
                                 return cucumber.supportCodeLibraryBuilder.finalize();
 
@@ -118,7 +119,7 @@ function cucumberRuntimeBuilder(version) {
                                     cwd: '/',
                                     eventBroadcaster,
                                     eventDataCollector,
-                                    log: (i) => logger.log(i),
+                                    log: (i) => logger.info(i),
                                     supportCodeLibrary,
                                 };
                                 cucumber.FormatterBuilder.build('progress', formatterOptions);

--- a/src/runtimes/javascript/cucumberjsRuntime.js
+++ b/src/runtimes/javascript/cucumberjsRuntime.js
@@ -28,7 +28,7 @@ function cucumberRuntimeBuilder(version) {
             stepDefinitions
                 .map(stepDefinitionFormatter)
                 // eslint-disable-next-line no-new-func
-                .forEach((i) => new Function('__dependencies', i)(dependencies));
+                .forEach((i) => new Function('__dependencies', 'console', i)(dependencies, logger));
         });
 
         let pickleFilter;
@@ -49,7 +49,7 @@ function cucumberRuntimeBuilder(version) {
             sources: features.map((i) => ({ data: i.source || '', uri: i.name || '' })),
             pickleFilter,
             type: 'progress',
-            logFn: (i) => logger.log(i),
+            logFn: (i) => logger.info(i),
         });
     }
 


### PR DESCRIPTION
Added `console` to function constructor for Cucumber.js runtime execution so that any console outputs from the step definitions are written to the test output instead of the browser's console.