### PR TITLE
Feature/fix status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testjam-io",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "testjam.io: An online coding environment specifically designed for Cucumber and Gherkin.",
   "main": "index.js",
   "scripts": {
@@ -58,7 +58,7 @@
     "styled-components": "^5.3.5"
   },
   "build": {
-    "version": "0.8.7",
+    "version": "0.8.8",
     "date": "2022-07-09T16:02:00Z"
   },
   "devDependencies": {

--- a/src/runtimes/javascript/cucumberjsRuntime.js
+++ b/src/runtimes/javascript/cucumberjsRuntime.js
@@ -24,6 +24,8 @@ function cucumberRuntimeBuilder(version) {
 
         logger.info(`Starting Cucumber.js ${version}...\n`);
         const supportCodeLibrary = cucumber.buildSupportCodeLibrary((cuke) => {
+            // eslint-disable-next-line no-param-reassign
+            cuke.Status = cucumber.Status;
             const dependencies = { ...packages, cucumber: cuke, '@cucumber/cucumber': cuke };
             stepDefinitions
                 .map(stepDefinitionFormatter)


### PR DESCRIPTION
- The `Status` object was being removed before being made available to the step definitions via `require()`. This is now fixed.